### PR TITLE
Peer dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": "^15.6.1",
+    "react": "^15.6.1 || ^16.8.0 || ^17.0.0",
     "react-router-dom": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates peer dependencies so that we can use this in perchweb, without having to use the `--legacy-peer-deps` flag, which we will then have to use evermore.

In terms of whether this is _actually_ compatible with react 17, it appears so, but tbh haven't checked everything. Considering we don't use this repo version, but (cvburgess's)[https://github.com/cvburgess/react-router-dynamic-breadcrumbs], it should casue no harm to merge this an then test it locally within perchweb